### PR TITLE
Converting NORScannerViewController to use a NORScannedPeripheral

### DIFF
--- a/nRF Toolbox/Scanner/NORScannedPeripheral.swift
+++ b/nRF Toolbox/Scanner/NORScannedPeripheral.swift
@@ -31,7 +31,9 @@ import CoreBluetooth
     }
     
     override func isEqual(_ object: Any?) -> Bool {
-        let otherPeripheral : NORScannedPeripheral = object as! NORScannedPeripheral
-        return peripheral == otherPeripheral.peripheral
+        if let otherPeripheral = object as? NORScannedPeripheral {
+            return peripheral == otherPeripheral.peripheral
+        }
+        return false
     }
 }


### PR DESCRIPTION
Fixes #26

To repro issue before the fix:
- Go to UART, tap Connect, choose a device to connect to
- Now go back to the main screen with icons
- Choose UART again
- Tap Connect
- It crashes 100% because `getConnectedPeripherals` returns a non-empty array of `CBPeripheral` values instead of `NORScannedPeripheral` values

This diff takes the value of `getConnectedPeripherals` and converts it to an array of `NORScannedPeripheral` items
