### PR TITLE
UART string sending and receiving

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,4 @@
 
 ### Contributors:
 * [Nikolaus Wittenstein](https://github.com/adzenith) CocoaPods 1.0.1 upgrade
+* [Michael Petrov](https://github.com/michaelpetrov) UART sending fixes for Swift 3

--- a/nRF Toolbox/UART/NORLogViewController.swift
+++ b/nRF Toolbox/UART/NORLogViewController.swift
@@ -48,7 +48,7 @@ class NORLogViewController: UIViewController, UITextFieldDelegate, UITableViewDa
     }
     
     func scrollDisplayViewDown() {
-        displayLogTextTable.scrollToRow(at: IndexPath(row: logItems!.count-1, section: 0), at: UITableViewScrollPosition.bottom, animated: true)
+        displayLogTextTable.scrollToRow(at: IndexPath(row: displayLogTextTable.numberOfRows(inSection: 0) - 1, section: 0), at: UITableViewScrollPosition.bottom, animated: true)
     }
 
 //    func setManager(aManager : NORBluetoothManager?) {


### PR DESCRIPTION
Fixes #28 

Makes sending UART strings compatible with the new Swift 3 `UnsafeMutableRawPointer` and fixes problem where the pointer value is sent instead of the string value for strings that are shorter than 20 characters.

Also fixes occasional scroll to bottom crash in `NORLogViewController.swift`
