### PR TITLE
Fixed Build Issues

### DIFF
--- a/nRF Toolbox.xcodeproj/project.pbxproj
+++ b/nRF Toolbox.xcodeproj/project.pbxproj
@@ -2073,7 +2073,7 @@
 			repositoryURL = "https://github.com/NordicPlayground/IOS-Common-Libraries.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.2.1;
+				version = 0.2.4;
 			};
 		};
 		018873CA2A583C3300253273 /* XCRemoteSwiftPackageReference "IOS-BLE-Library" */ = {

--- a/nRF-Toolbox/Screens/Services/CGMS/CGMSView.swift
+++ b/nRF-Toolbox/Screens/Services/CGMS/CGMSView.swift
@@ -49,12 +49,13 @@ struct CGMSView: View {
             }
         }
         
-        InlinePicker(title: "Mode", systemImage: "square.on.square", selectedValue: $mode) { newMode in
-            Task {
-                await viewModel.requestRecords(newMode.recordOperator)
+        InlinePicker(title: "Mode", systemImage: "square.on.square", selectedValue: $mode)
+            .onChange(of: mode) {
+                Task {
+                    await viewModel.requestRecords(mode.recordOperator)
+                }
             }
-        }
-        .labeledContentStyle(.accentedContent)
+            .labeledContentStyle(.accentedContent)
     }
     
     @ViewBuilder

--- a/nRF-Toolbox/Screens/Services/Glucose/GlucoseView.swift
+++ b/nRF-Toolbox/Screens/Services/Glucose/GlucoseView.swift
@@ -76,26 +76,27 @@ struct GlucoseView: View {
             }
         }
         
-        InlinePicker(title: "Mode", systemImage: "square.on.square", selectedValue: $viewMode) { newMode in
-            viewModel.requestRecords(newMode.recordOperator)
-        }
-        .labeledContentStyle(.accentedContent)
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    switch viewMode {
-                    case .all:
-                        viewModel.requestRecords(.allRecords)
-                    case .first:
-                        viewModel.requestRecords(.firstRecord)
-                    case .last:
-                        viewModel.requestRecords(.lastRecord)
+        InlinePicker(title: "Mode", systemImage: "square.on.square", selectedValue: $viewMode)
+            .onChange(of: viewMode) {
+                viewModel.requestRecords(viewMode.recordOperator)
+            }
+            .labeledContentStyle(.accentedContent)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        switch viewMode {
+                        case .all:
+                            viewModel.requestRecords(.allRecords)
+                        case .first:
+                            viewModel.requestRecords(.firstRecord)
+                        case .last:
+                            viewModel.requestRecords(.lastRecord)
+                        }
+                    } label: {
+                        Image(systemName: "arrow.counterclockwise")
                     }
-                } label: {
-                    Image(systemName: "arrow.counterclockwise")
                 }
             }
-        }
     }
     
     // MARK: noDataView()


### PR DESCRIPTION
The project was not building, mostly because InlinePicker removed its onChange-ish callback. It was removed because adding closures in a View's init causes SwiftUI inefficiencies since SwiftUI cannot compare closures, so it always assumes the View has changed, even though it might not have.